### PR TITLE
Wstool

### DIFF
--- a/gravl.rosinstall
+++ b/gravl.rosinstall
@@ -1,3 +1,7 @@
 - git:
     local-name: swiftnav_ros
-    uri: git clone https://github.com/swift-nav/swiftnav_ros
+    uri: https://github.com/swift-nav/swiftnav_ros
+
+- git:
+    local-name: gravl
+    uri: https://github.com/olinrobotics/gravl.git

--- a/gravl.rosinstall
+++ b/gravl.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: swiftnav_ros
+    uri: git clone https://github.com/swift-nav/swiftnav_ros

--- a/gravl.rosinstall
+++ b/gravl.rosinstall
@@ -1,7 +1,10 @@
 - git:
-    local-name: swiftnav_ros
-    uri: https://github.com/swift-nav/swiftnav_ros
-
-- git:
     local-name: gravl
     uri: https://github.com/olinrobotics/gravl.git
+
+# GPS module
+# Before uncommenting, install libsbp:
+# https://github.com/olinrobotics/gravl/wiki/Swift-Navigation-RTK-GPS
+# - git:
+#     local-name: swiftnav_ros
+#     uri: https://github.com/swift-nav/swiftnav_ros

--- a/package.xml
+++ b/package.xml
@@ -4,41 +4,10 @@
   <version>0.0.0</version>
   <description>Olin's ground robotic autonomous vehicle lab repo</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="carl.moser@students.olin.edu">carl</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/tractor</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>ackermann_msgs</build_depend>
@@ -69,11 +38,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>


### PR DESCRIPTION
This covers all things git, it even clones this repository for you.
Simply move gravl.rosinstall to catkin_ws/src/.rosinstall and wstool update -t src to setup dependencies.
To create a fresh workspace, copy the gravl.rosinstall somewhere on your computer and run `wstool init src <path-to-gravl.rosinstall` in a fresh catkin_ws. Then install build/run dependencies with `rosdep install -iry --from-paths src`.