### PR TITLE
Packagexml2: Fixing the overwrite

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,8 +27,11 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>
+  <exec_depend>phidgets-imu</exec_depend>
+  <exec_depend>nmea_navsat_driver</exec_depend>
+  <exec_depend>rosserial</exec_depend>
+  <exec_depend>pointgrey-camera-driver</exec_depend>
+  <exec_depend>urg-node</exec_depend>
 
   <export></export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,12 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
 
   <export></export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>phidgets-imu</exec_depend>
   <exec_depend>nmea_navsat_driver</exec_depend>
+  <exec_depend>swiftnav_ros</exec_depend>
   <exec_depend>rosserial</exec_depend>
   <exec_depend>pointgrey_camera_driver</exec_depend>
   <exec_depend>urg_node</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -18,18 +18,15 @@
   <depend>mavros_msgs</depend>
   <depend>message_generation</depend>
   <depend>nav_msgs</depend>
-  <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
 
-  <exec_depend>rospy</exec_depend>
+  <build_depend>roscpp</build_depend>
+
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -21,17 +21,17 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
+  <depend>rospy</depend>
 
   <build_depend>roscpp</build_depend>
 
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>rospy</exec_depend>
   <exec_depend>phidgets-imu</exec_depend>
   <exec_depend>nmea_navsat_driver</exec_depend>
   <exec_depend>rosserial</exec_depend>
-  <exec_depend>pointgrey-camera-driver</exec_depend>
-  <exec_depend>urg-node</exec_depend>
+  <exec_depend>pointgrey_camera_driver</exec_depend>
+  <exec_depend>urg_node</exec_depend>
 
   <export></export>
 </package>


### PR DESCRIPTION
Looks like the last package.xml that I did today was overwritten by the other pull request for the older package-xml2 branch. That's fine, I re-added the new dependencies for the new format so things catkin make. Some things can probably be cleaned up, such as the generic (build and run) dependency on rospy as well as in the CMakeLists, but that can be dealt with later. 

Also, I removed the swiftnav dependency due to the weird installation of libsbp. I will document that later, but it is not required to catkin_make anyways.