### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+ARG DISTRO=kinetic
+
+FROM ros:$DISTRO
+
+ARG USER=kubo
+ARG LIBSBP_V=2.3.10
+
+MAINTAINER Kawin Nikomborirak concavemail@gmail.com
+
+# Prerequisites
+# The wget to the make install is to install libsbp for swiftnav.
+RUN bash -c \
+    'apt-get update \
+    && apt-get install -y wget \
+    && useradd -lmG video $USER \
+    && wget -O libsbp.tar.gz https://github.com/swift-nav/libsbp/archive/v$LIBSBP_V.tar.gz \
+    && tar xvf libsbp.tar.gz \
+    && cd libsbp-$LIBSBP_V/c \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make \
+    && make install \
+
+    && mkdir -p /home/$USER/catkin_ws/src/gravl'
+
+WORKDIR /home/$USER/catkin_ws
+COPY . src/gravl/
+COPY gravl.rosinstall src/.rosinstall
+
+# Install dependencies
+RUN bash -c \
+    'wstool update -t src \
+    && chown -R $USER . \
+    && rosdep update \
+    && rosdep install -iry --from-paths src'
+
+USER $USER
+
+# Catkin make
+RUN bash -c \
+    'source /opt/ros/$ROS_DISTRO/setup.bash \
+    && catkin_make \
+    && source devel/setup.bash \
+    && echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc'
+
+WORKDIR /home/$USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN bash -c \
     && cmake .. \
     && make \
     && make install \
-
     && mkdir -p /home/$USER/catkin_ws/src/gravl'
 
 WORKDIR /home/$USER/catkin_ws

--- a/gravl.rosinstall
+++ b/gravl.rosinstall
@@ -1,10 +1,3 @@
 - git:
-    local-name: gravl
-    uri: https://github.com/olinrobotics/gravl.git
-
-# GPS module
-# Before uncommenting, install libsbp:
-# https://github.com/olinrobotics/gravl/wiki/Swift-Navigation-RTK-GPS
-# - git:
-#     local-name: swiftnav_ros
-#     uri: https://github.com/swift-nav/swiftnav_ros
+    local-name: swiftnav_ros
+    uri: https://github.com/swift-nav/swiftnav_ros

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
 
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>phidgets-imu</exec_depend>
+  <exec_depend>phidgets_imu</exec_depend>
   <exec_depend>nmea_navsat_driver</exec_depend>
   <exec_depend>swiftnav_ros</exec_depend>
   <exec_depend>rosserial</exec_depend>


### PR DESCRIPTION
I changed the rosinstall file for git dependencies because it will only be used by docker. The installation of swiftnav is not necessary for a dev environment, and the dependency on libsbp is not elegant.

To build the docker image, `docker build -t gravl .`
To run the image, `docker run --privileged -it --rm gravl`.
Commands run in this console will publish the roscore stuff to the host system and also have access to the ports of the logged in user.