### PR TITLE
Use underscore for Phidgets

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
 
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>phidgets-imu</exec_depend>
+  <exec_depend>phidgets_imu</exec_depend>
   <exec_depend>nmea_navsat_driver</exec_depend>
   <exec_depend>swiftnav_ros</exec_depend>
   <exec_depend>rosserial</exec_depend>


### PR DESCRIPTION
In the output of rosdep install, you may notice that there is a failure to locate phidgets-imu. That is because it is actually called phidgets_imu. Luckily this was not required in the catkin_make, though @nathanestill will need this for his work.