### PR TITLE
Add apt-get upgrade to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY gravl.rosinstall /home/$DOCKER_USER/catkin_ws/src/.rosinstall
 
 RUN bash -c \
     'apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y wget \
     && wget -O libsbp.tar.gz https://github.com/swift-nav/libsbp/archive/v$LIBSBP_V.tar.gz \
     && tar xvf libsbp.tar.gz \


### PR DESCRIPTION
Since our docker image builds off of the ROS provided kinetic snapshot, not all the packages are up-to-date. This causes newly installed dependencies such as phidgets (imu) to have some message mismatches and fail. Adding `apt-get upgrade -y` fixes that problem.