### PR TITLE
Encoder Odometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_message_files(
   Hemisphere.msg
   RoboClawStats.msg
   ImuSafety.msg
+  DiffDrive.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -142,6 +143,7 @@ add_executable( idk src/arm_drone.cpp )
 add_executable( road_detection src/road_detection.cpp )
 add_executable(imu_safety src/imu_safety/ImuSafety.cpp)
 add_executable(imu_base src/ImuBase/ImuBase.cpp)
+add_executable(enc_odom src/EncOdom/EncOdom.cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries( Camera ${OpenCV_LIBS} ${catkin_LIBRARIES} )
@@ -154,6 +156,7 @@ target_link_libraries( idk ${catkin_LIBRARIES} )
 target_link_libraries( road_detection ${OpenCV_LIBS} )
 target_link_libraries(imu_safety ${catkin_LIBRARIES})
 target_link_libraries(imu_base ${catkin_LIBRARIES})
+target_link_libraries(enc_odom ${catkin_LIBRARIES})
 
 
 ## Add cmake target dependencies of the executable
@@ -161,6 +164,7 @@ target_link_libraries(imu_base ${catkin_LIBRARIES})
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 add_dependencies(Hemisphere ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 add_dependencies(imu_safety ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(enc_odom ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 
 #IF(Qt5Widgets_FOUND)

--- a/msg/DiffDrive.msg
+++ b/msg/DiffDrive.msg
@@ -1,0 +1,3 @@
+float64 wheelbase
+float64 rvel
+float64 lvel

--- a/src/EncOdom/EncOdom.cpp
+++ b/src/EncOdom/EncOdom.cpp
@@ -1,17 +1,38 @@
 #include "EncOdom.h"
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 EncOdom::EncOdom()
   : sub(nh.subscribe("diffdrive_raw", 100, &EncOdom::callback, this))
   , then(ros::Time::now())
-{}
+{
+  transformStamped.header.frame_id = "odom";
+  transformStamped.child_frame_id = "base_link";
+}
 
 void EncOdom::callback(const gravl::DiffDrive::ConstPtr& msg)
 {
   const auto now = ros::Time::now();
-  const auto omega = (msg->rvel - msg->lvel) / msg->wheelbase;
-  const auto xdot = (msg->rvel + msg->lvel) / 2;
+  const auto angularVel = (msg->rvel - msg->lvel) / msg->wheelbase;
+  const auto tangentialVel = (msg->rvel + msg->lvel) / 2;
+  const auto dt = (now - then).toSec();
+
+  tf2::Quaternion deltaAngle;
+  deltaAngle.setRPY(angularVel * dt, 0, 0);
+  tf2::Quaternion oldOrientation;
+  tf2::convert(transformStamped.transform.rotation, oldOrientation);
+  const auto newOrientation = oldOrientation * deltaAngle;
+  tf2::convert(oldOrientation * deltaAngle, transformStamped.transform.rotation);
+
+  const auto delta_position = tf2::quatRotate(newOrientation, tf2::Vector3(0, 0, tangentialVel * dt));
+  tf2::convert(delta_position, transformStamped.transform.translation);
+
+  br.sendTransform(transformStamped);
+  then = now;
 }
 
 int main(int argc, char** argv)
 {
+  ros::init(argc, argv, "enc_odom");
+  EncOdom encOdom;
+  ros::spin();
 }

--- a/src/EncOdom/EncOdom.cpp
+++ b/src/EncOdom/EncOdom.cpp
@@ -1,0 +1,17 @@
+#include "EncOdom.h"
+
+EncOdom::EncOdom()
+  : sub(nh.subscribe("diffdrive_raw", 100, &EncOdom::callback, this))
+  , then(ros::Time::now())
+{}
+
+void EncOdom::callback(const gravl::DiffDrive::ConstPtr& msg)
+{
+  const auto now = ros::Time::now();
+  const auto omega = (msg->rvel - msg->lvel) / msg->wheelbase;
+  const auto xdot = (msg->rvel + msg->lvel) / 2;
+}
+
+int main(int argc, char** argv)
+{
+}

--- a/src/EncOdom/EncOdom.cpp
+++ b/src/EncOdom/EncOdom.cpp
@@ -16,12 +16,10 @@ void EncOdom::callback(const gravl::DiffDrive::ConstPtr& msg)
   const auto tangentialVel = (msg->rvel + msg->lvel) / 2;
   const auto dt = (now - then).toSec();
 
-  tf2::Quaternion deltaAngle;
-  deltaAngle.setRPY(angularVel * dt, 0, 0);
   tf2::Quaternion oldOrientation;
   tf2::convert(transformStamped.transform.rotation, oldOrientation);
-  const auto newOrientation = oldOrientation * deltaAngle;
-  tf2::convert(oldOrientation * deltaAngle, transformStamped.transform.rotation);
+  const auto newOrientation = oldOrientation * tf2::Vector3(0, 0, angularVel * dt);
+  tf2::convert(newOrientation, transformStamped.transform.rotation);
 
   const auto delta_position = tf2::quatRotate(newOrientation, tf2::Vector3(0, 0, tangentialVel * dt));
   tf2::convert(delta_position, transformStamped.transform.translation);

--- a/src/EncOdom/EncOdom.h
+++ b/src/EncOdom/EncOdom.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <gravl/DiffDrive.h>
+#include <tf2_ros/transform_broadcaster.h>
+
+class EncOdom
+{
+public:
+  EncOdom();
+
+private:
+  void callback(const gravl::DiffDrive::ConstPtr& msg);
+
+  ros::NodeHandle nh;
+  tf2_ros::TransformBroadcaster br;
+  ros::Subscriber sub;
+  geometry_msgs::TransformStamped transformStamped;
+  ros::Time then;
+};


### PR DESCRIPTION
This subscribes to the diffdrive_raw topic and broadcasts a transform from odom to base_link. There are a few uncertainties, such as my assumption that tf2::Vector3 is implicitly converted from RPY to a quaternion with https://docs.ros.org/kinetic/api/tf2/html/namespacetf2.html#a701335dd7331e8391843b31dd89746a6. However, that is a predictable and harmless fix so we only stand to gain by pushing this into master.